### PR TITLE
fix: use selected UI style when refining widgets

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
     }
 
     const effectiveMode = (session.mode || mode) as ChatMode
-    const effectiveUIStyle = (session.uiStyle || uiStyle) as UIStyle
+    const effectiveUIStyle = (uiStyle || session.uiStyle) as UIStyle
     const isRefine = Boolean(session.widgetCode)
 
     let writerClosed = false
@@ -149,6 +149,14 @@ export async function POST(request: NextRequest) {
         if (!userMessage) return
 
         if (isRefine) {
+          // Fetch UI style preset for refinement
+          const uiStylePreset = await prisma.uIStylePreset.findUnique({
+            where: { name: effectiveUIStyle },
+          })
+          if (!uiStylePreset) {
+            throw new Error(`UI style preset not found: ${effectiveUIStyle}`)
+          }
+
           if (
             !(await createAndSend({
               sessionId: session.id,
@@ -170,6 +178,7 @@ export async function POST(request: NextRequest) {
               body: JSON.stringify({
                 previousCode,
                 refinePrompt: input,
+                uiStylePrompt: uiStylePreset.promptAddition,
                 apiKey,
                 llmConfig,
               }),
@@ -182,7 +191,7 @@ export async function POST(request: NextRequest) {
           }
 
           const { code: widgetCode } = await widgetResponse.json()
-          const refineMessages = buildWidgetRefineMessages(previousCode, input)
+          const refineMessages = buildWidgetRefineMessages(previousCode, input, uiStylePreset.promptAddition)
           const refinePromptPayload = JSON.stringify(
             [
               { role: 'system', content: refineMessages.system },
@@ -207,6 +216,7 @@ export async function POST(request: NextRequest) {
           if (
             !(await safeUpdateSession({
               widgetCode,
+              uiStyle: effectiveUIStyle,
               status: 'completed',
             }))
           ) {

--- a/src/app/api/generate/widget/route.ts
+++ b/src/app/api/generate/widget/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
 
     const messages = isRefine
       ? (() => {
-          const refineMessages = buildWidgetRefineMessages(previousCode, refinePrompt)
+          const refineMessages = buildWidgetRefineMessages(previousCode, refinePrompt, uiStylePrompt)
           return [
             { role: 'system', content: refineMessages.system },
             { role: 'user', content: refineMessages.user },

--- a/src/lib/llm/prompt-builder.ts
+++ b/src/lib/llm/prompt-builder.ts
@@ -62,10 +62,15 @@ export function buildWidgetPrompt(
 
 export function buildWidgetRefineMessages(
   previousCode: string,
-  refinePrompt: string
+  refinePrompt: string,
+  uiStylePrompt?: string
 ): { system: string; user: string } {
+  let system = WIDGET_REFINE_SYSTEM_PROMPT
+  if (uiStylePrompt) {
+    system += `\n\nUI Style Guide:\n${uiStylePrompt}`
+  }
   return {
-    system: WIDGET_REFINE_SYSTEM_PROMPT,
+    system,
     user: `${previousCode}\n\n${refinePrompt}`,
   }
 }


### PR DESCRIPTION
Files changed:                                                                                                                                                
  1. src/app/api/chat/route.ts — The refine path now fetches the UIStylePreset and passes uiStylePrompt to the widget generation call. 
  2. src/lib/llm/prompt-builder.ts — buildWidgetRefineMessages accepts an optional uiStylePrompt and appends it as a "UI Style Guide" section to the refine system prompt.
  3. src/app/api/generate/widget/route.ts — Passes uiStylePrompt through to buildWidgetRefineMessages during refinement.

before commit (change to glassmorphism theme):
<img width="2784" height="896" alt="image" src="https://github.com/user-attachments/assets/65071dbe-ca51-4a67-8adb-3f654530e4a4" />


after commit (change to glassmorphism theme):
<img width="2375" height="820" alt="image" src="https://github.com/user-attachments/assets/5f421dd4-f940-483c-a995-a2787babe125" />

