### PR TITLE
fix: prevent Sandpack timeout when switching between widget previews

### DIFF
--- a/src/components/chat/CustomMessage.tsx
+++ b/src/components/chat/CustomMessage.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { Box, Typography } from '@mui/material'
 import { MockDataResponse } from '@/types/widget'
-import { WidgetPreview } from '../widget/WidgetPreview'
 import { MockDataPreview } from '../widget/MockDataPreview'
 import { AppMetadataPreview } from '../widget/AppMetadataPreview'
 import { ChatMessage, Provider } from '@/types/chat'
@@ -87,8 +86,6 @@ export function CustomMessage({
     return (
       <WidgetCodeMessage
         code={code}
-        prompt={message.data.prompt}
-        mockData={mockData}
         provider={provider}
         enableLivePreview={enableLivePreview}
         onRequestLivePreview={
@@ -229,15 +226,11 @@ function MockDataMessage({ mockData, provider }: { mockData: MockDataResponse; p
 
 function WidgetCodeMessage({
   code,
-  prompt,
-  mockData,
   provider,
   enableLivePreview,
   onRequestLivePreview,
 }: {
   code: string
-  prompt?: string
-  mockData?: MockDataResponse
   provider: Provider
   enableLivePreview: boolean
   onRequestLivePreview?: () => void
@@ -252,9 +245,9 @@ function WidgetCodeMessage({
           <Typography sx={{ color: '#ececec', fontSize: 14, mb: 1.5, fontWeight: 500 }}>
             Here's your widget:
           </Typography>
-          {enableLivePreview && canRenderCode ? (
-            <WidgetPreview code={code} mockData={mockData} prompt={prompt} />
-          ) : (
+          {/* Live preview is rendered by Thread with a stable key —
+              only show the static code block for inactive widgets. */}
+          {!enableLivePreview && (
             <Box
               sx={{
                 border: '1px solid #4d4d4d',

--- a/src/components/chat/Thread.tsx
+++ b/src/components/chat/Thread.tsx
@@ -6,6 +6,7 @@ import { CustomMessage } from './CustomMessage'
 import { CustomComposer } from './CustomComposer'
 import { ChatHeader } from './ChatHeader'
 import { useChatContext } from './ChatProvider'
+import { WidgetPreview } from '../widget/WidgetPreview'
 import { Provider } from '@/types/chat'
 import Image from 'next/image'
 
@@ -37,6 +38,10 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
   }
 
   // Only mount one live Sandpack runtime at a time.
+  // The WidgetPreview sits at a fixed DOM position (never moved — moving
+  // iframes causes them to reload). CSS flex `order` places it visually
+  // after the active widget message. FileUpdater swaps the code via
+  // sandpack.updateFile() when the active widget changes.
   const latestWidgetMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].messageType === 'widget-code') {
@@ -56,6 +61,27 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  // Compute the active widget's data for the single WidgetPreview instance.
+  const activeWidgetData = useMemo(() => {
+    if (!activeLivePreviewMessageId) return null
+    const index = messages.findIndex((m) => m.id === activeLivePreviewMessageId)
+    if (index === -1) return null
+    const message = messages[index]
+    if (message.messageType !== 'widget-code' || !message.data) return null
+
+    const code =
+      typeof message.data?.code === 'string'
+        ? message.data.code
+        : typeof message.content === 'string'
+          ? message.content
+          : ''
+    const mockData = getMockDataForMessage(index)
+    const prompt = message.data?.prompt
+
+    return { code, mockData, prompt, index }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, activeLivePreviewMessageId])
 
   return (
     <Box
@@ -141,18 +167,47 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
             </Box>
           </Box>
         ) : (
-          <>
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             {messages.map((message, index) => (
-              <CustomMessage
-                key={message.id}
-                message={message}
-                mockData={getMockDataForMessage(index)}
-                enableLivePreview={message.id === activeLivePreviewMessageId}
-                onRequestLivePreview={(messageId) => setActiveLivePreviewMessageId(messageId)}
-              />
+              <Box key={message.id} sx={{ order: index * 2 }}>
+                <CustomMessage
+                  message={message}
+                  mockData={getMockDataForMessage(index)}
+                  enableLivePreview={message.id === activeLivePreviewMessageId}
+                  onRequestLivePreview={(messageId) => setActiveLivePreviewMessageId(messageId)}
+                />
+              </Box>
             ))}
+            {/* Single WidgetPreview at a fixed DOM position.
+                CSS order places it visually after the active message.
+                FileUpdater swaps the code without remounting Sandpack. */}
+            {activeWidgetData && (
+              <Box
+                sx={{
+                  order: activeWidgetData.index * 2 + 1,
+                  bgcolor: '#2f2f2f',
+                  px: { xs: 3, md: 4 },
+                  pb: 2.5,
+                }}
+              >
+                <Box
+                  sx={{
+                    maxWidth: '90%',
+                    width: '90%',
+                    mx: 'auto',
+                    pl: '42px',
+                  }}
+                >
+                  <WidgetPreview
+                    code={activeWidgetData.code}
+                    mockData={activeWidgetData.mockData}
+                    prompt={activeWidgetData.prompt}
+                  />
+                </Box>
+              </Box>
+            )}
             {isLoading && messages.length > 0 && (
-              <Box sx={{ bgcolor: '#2f2f2f', py: 2.5, px: 4 }}>
+              <Box sx={{ order: messages.length * 2 + 2, bgcolor: '#2f2f2f', py: 2.5, px: 4 }}>
                 <Box sx={{ maxWidth: '90%', width: '90%', mx: 'auto', display: 'flex', gap: 2 }}>
                   <Box
                     sx={{
@@ -220,8 +275,8 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
                 </Box>
               </Box>
             )}
-            <div ref={messagesEndRef} />
-          </>
+            <div ref={messagesEndRef} style={{ order: messages.length * 2 + 3 }} />
+          </Box>
         )}
       </Box>
 

--- a/src/components/widget/WidgetPreview.tsx
+++ b/src/components/widget/WidgetPreview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   SandpackProvider,
   SandpackLayout,
@@ -198,6 +198,29 @@ function SandpackContent({ prompt }: { prompt?: string }) {
   )
 }
 
+// Imperatively update Sandpack files when props change, so the
+// SandpackProvider never needs to unmount/remount.
+function FileUpdater({ code, mockData }: { code: string; mockData: any }) {
+  const { sandpack } = useSandpack()
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    // Skip the initial render — SandpackProvider already has the right files.
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    sandpack.updateFile('/App.tsx', code)
+    sandpack.updateFile(
+      '/response.json',
+      JSON.stringify(mockData || { widget: null, data: null, meta: null }, null, 2)
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code, mockData])
+
+  return null
+}
+
 export function WidgetPreview({ code, mockData, prompt }: WidgetPreviewProps) {
   const files = {
     '/App.tsx': {
@@ -258,6 +281,7 @@ export function WidgetPreview({ code, mockData, prompt }: WidgetPreviewProps) {
         },
       }}
     >
+      <FileUpdater code={code} mockData={mockData} />
       <SandpackContent prompt={prompt} />
     </SandpackProvider>
   )


### PR DESCRIPTION
 ## Summary
  - Fixed Sandpack "Couldn't connect to server / TIME_OUT" errors when clicking
    "Load live preview" on older widget iterations
  - The root cause was that switching previews destroyed and recreated the
    SandpackProvider, forcing the bundler to reinitialize (download deps,
    recompile) — which frequently timed out
  - Now a single SandpackProvider is kept alive at a fixed DOM position and
    CSS flex `order` places it visually after whichever widget message is active
  - A new `FileUpdater` component calls `sandpack.updateFile()` to swap code
    without remounting, so switching between widget versions is instant