### PR TITLE
fix: consistent default UI style when creating new chat

### DIFF
--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -89,7 +89,7 @@ export function ChatProvider({ children, apiKey, llmConfig, setLLMConfig }: Chat
     setCurrentSessionId(null)
     setMessages([])
     setCurrentMode('description')
-    setCurrentUIStyle('modern-minimal')
+    setCurrentUIStyle('ios-stock-widget')
   }
 
   return (


### PR DESCRIPTION
Previously there was a small inconsistency: when reloading the page, the theme would default to "iOS stock widget" while creating a new chat defaulted to "Modern Minimal". Changed to have a consistent default theme