### PR TITLE
fix: auto-recover Sandpack preview after tab switch timeout

### DIFF
--- a/src/components/widget/WidgetPreview.tsx
+++ b/src/components/widget/WidgetPreview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   SandpackProvider,
   SandpackLayout,
@@ -18,8 +18,22 @@ interface WidgetPreviewProps {
 }
 
 function SandpackContent({ prompt }: { prompt?: string }) {
-  const { sandpack } = useSandpack()
+  const { sandpack, dispatch } = useSandpack()
   const [copied, setCopied] = useState(false)
+
+  // Recover Sandpack when the user switches back to this tab.
+  // Browsers throttle/suspend backgrounded iframes, which causes
+  // the Sandpack bundler to time out and show an error.
+  const handleVisibilityChange = useCallback(() => {
+    if (document.visibilityState === 'visible' && sandpack.status === 'timeout') {
+      dispatch({ type: 'refresh' })
+    }
+  }, [sandpack.status, dispatch])
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [handleVisibilityChange])
 
   // Get the active file from sandpack
   const activeFile = sandpack.activeFile


### PR DESCRIPTION
## Summary                                                                                                                                  
  - When users switch to a different browser tab while a widget preview is loaded, the Sandpack bundler iframe gets suspended by the browser and times out
  - Added a `visibilitychange` listener that detects when the tab becomes active again and automatically refreshes Sandpack if it's in a timeout state