### PR TITLE
fix: show widget code and preview button for all generations

### DIFF
--- a/src/components/chat/CustomMessage.tsx
+++ b/src/components/chat/CustomMessage.tsx
@@ -48,15 +48,11 @@ function AIIcon({ provider }: { provider: Provider }) {
 interface CustomMessageProps {
   message: ChatMessage
   mockData?: MockDataResponse
-  enableLivePreview?: boolean
-  onRequestLivePreview?: (messageId: string) => void
 }
 
 export function CustomMessage({
   message,
   mockData,
-  enableLivePreview = false,
-  onRequestLivePreview,
 }: CustomMessageProps) {
   const { provider, setActivePreview } = useChatContext()
 
@@ -87,12 +83,6 @@ export function CustomMessage({
       <WidgetCodeMessage
         code={code}
         provider={provider}
-        enableLivePreview={enableLivePreview}
-        onRequestLivePreview={
-          typeof onRequestLivePreview === 'function'
-            ? () => onRequestLivePreview(message.id)
-            : undefined
-        }
         onViewPreview={() => setActivePreview({ code, mockData, prompt: message.data.prompt })}
       />
     )
@@ -228,14 +218,10 @@ function MockDataMessage({ mockData, provider }: { mockData: MockDataResponse; p
 function WidgetCodeMessage({
   code,
   provider,
-  enableLivePreview,
-  onRequestLivePreview,
   onViewPreview,
 }: {
   code: string
   provider: Provider
-  enableLivePreview: boolean
-  onRequestLivePreview?: () => void
   onViewPreview: () => void
 }) {
   const canRenderCode = typeof code === 'string' && code.trim().length > 0
@@ -248,67 +234,63 @@ function WidgetCodeMessage({
           <Typography sx={{ color: '#ececec', fontSize: 14, mb: 1.5, fontWeight: 500 }}>
             Here's your widget:
           </Typography>
-          {/* Live preview is rendered by Thread with a stable key —
-              only show the static code block for inactive widgets. */}
-          {!enableLivePreview && (
+          <Box
+            sx={{
+              border: '1px solid #4d4d4d',
+              borderRadius: 1,
+              overflow: 'hidden',
+              bgcolor: '#1e1e1e',
+            }}
+          >
             <Box
               sx={{
-                border: '1px solid #4d4d4d',
-                borderRadius: 1,
-                overflow: 'hidden',
-                bgcolor: '#1e1e1e',
+                px: 2,
+                py: 1,
+                bgcolor: '#2a2a2a',
+                borderBottom: '1px solid #4d4d4d',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
               }}
             >
+              <Typography sx={{ color: '#c5c5d2', fontSize: 12 }}>
+                Widget code
+              </Typography>
               <Box
+                component="button"
+                onClick={onViewPreview}
                 sx={{
-                  px: 2,
-                  py: 1,
-                  bgcolor: '#2a2a2a',
-                  borderBottom: '1px solid #4d4d4d',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  gap: 2,
-                }}
-              >
-                <Typography sx={{ color: '#c5c5d2', fontSize: 12 }}>
-                  Live preview paused to reduce Sandpack timeouts
-                </Typography>
-                <Box
-                  component="button"
-                  onClick={onViewPreview}
-                  sx={{
-                    border: '1px solid #10a37f',
-                    background: 'transparent',
-                    color: '#10a37f',
-                    borderRadius: 1,
-                    px: 1.5,
-                    py: 0.5,
-                    fontSize: 12,
-                    cursor: 'pointer',
-                    '&:hover': { bgcolor: 'rgba(16,163,127,0.1)' },
-                  }}
-                >
-                  View preview
-                </Box>
-              </Box>
-              <Box
-                component="pre"
-                sx={{
-                  m: 0,
-                  p: 2,
-                  maxHeight: 300,
-                  overflow: 'auto',
+                  border: '1px solid #10a37f',
+                  background: 'transparent',
+                  color: '#10a37f',
+                  borderRadius: 1,
+                  px: 1.5,
+                  py: 0.5,
                   fontSize: 12,
-                  lineHeight: 1.5,
-                  color: '#d4d4d4',
-                  fontFamily: '"Fira Code", "Fira Mono", Consolas, Monaco, monospace',
+                  cursor: 'pointer',
+                  '&:hover': { bgcolor: 'rgba(16,163,127,0.1)' },
                 }}
               >
-                {canRenderCode ? code : 'No widget code found in this message.'}
+                View preview
               </Box>
             </Box>
-          )}
+            <Box
+              component="pre"
+              sx={{
+                m: 0,
+                p: 2,
+                maxHeight: 300,
+                overflow: 'auto',
+                fontSize: 12,
+                lineHeight: 1.5,
+                color: '#d4d4d4',
+                fontFamily: '"Fira Code", "Fira Mono", Consolas, Monaco, monospace',
+              }}
+            >
+              {canRenderCode ? code : 'No widget code found in this message.'}
+            </Box>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/src/components/chat/Thread.tsx
+++ b/src/components/chat/Thread.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Box, Typography, CircularProgress } from '@mui/material'
 import { CustomMessage } from './CustomMessage'
 import { CustomComposer } from './CustomComposer'
 import { ChatHeader } from './ChatHeader'
 import { useChatContext } from './ChatProvider'
-import { WidgetPreview } from '../widget/WidgetPreview'
 import { Provider } from '@/types/chat'
 import Image from 'next/image'
 
@@ -16,7 +15,7 @@ interface ThreadProps {
 }
 
 export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
-  const { messages, isLoading, provider, setActivePreview, activePreview } = useChatContext()
+  const { messages, isLoading, provider, setActivePreview } = useChatContext()
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   const iconMap: Record<Provider, string> = {
@@ -37,11 +36,7 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
     return undefined
   }
 
-  // Only mount one live Sandpack runtime at a time.
-  // The WidgetPreview sits at a fixed DOM position (never moved — moving
-  // iframes causes them to reload). CSS flex `order` places it visually
-  // after the active widget message. FileUpdater swaps the code via
-  // sandpack.updateFile() when the active widget changes.
+  // Track the latest widget message to auto-open the panel preview
   const latestWidgetMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].messageType === 'widget-code') {
@@ -50,12 +45,6 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
     }
     return null
   }, [messages])
-  const [activeLivePreviewMessageId, setActiveLivePreviewMessageId] = useState<string | null>(null)
-
-  // Default active preview to the latest widget whenever messages change.
-  useEffect(() => {
-    setActiveLivePreviewMessageId(latestWidgetMessageId)
-  }, [latestWidgetMessageId])
 
   // Auto-open panel preview for the latest widget
   useEffect(() => {
@@ -76,27 +65,6 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
-
-  // Compute the active widget's data for the single WidgetPreview instance.
-  const activeWidgetData = useMemo(() => {
-    if (!activeLivePreviewMessageId) return null
-    const index = messages.findIndex((m) => m.id === activeLivePreviewMessageId)
-    if (index === -1) return null
-    const message = messages[index]
-    if (message.messageType !== 'widget-code' || !message.data) return null
-
-    const code =
-      typeof message.data?.code === 'string'
-        ? message.data.code
-        : typeof message.content === 'string'
-          ? message.content
-          : ''
-    const mockData = getMockDataForMessage(index)
-    const prompt = message.data?.prompt
-
-    return { code, mockData, prompt, index }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages, activeLivePreviewMessageId])
 
   return (
     <Box
@@ -188,39 +156,9 @@ export function Thread({ onToggleSidebar, onSettingsClick }: ThreadProps) {
                 <CustomMessage
                   message={message}
                   mockData={getMockDataForMessage(index)}
-                  enableLivePreview={message.id === activeLivePreviewMessageId}
-                  onRequestLivePreview={(messageId) => setActiveLivePreviewMessageId(messageId)}
                 />
               </Box>
             ))}
-            {/* Single WidgetPreview at a fixed DOM position.
-                CSS order places it visually after the active message.
-                FileUpdater swaps the code without remounting Sandpack. */}
-            {activeWidgetData && !activePreview && (
-              <Box
-                sx={{
-                  order: activeWidgetData.index * 2 + 1,
-                  bgcolor: '#2f2f2f',
-                  px: { xs: 3, md: 4 },
-                  pb: 2.5,
-                }}
-              >
-                <Box
-                  sx={{
-                    maxWidth: '90%',
-                    width: '90%',
-                    mx: 'auto',
-                    pl: '42px',
-                  }}
-                >
-                  <WidgetPreview
-                    code={activeWidgetData.code}
-                    mockData={activeWidgetData.mockData}
-                    prompt={activeWidgetData.prompt}
-                  />
-                </Box>
-              </Box>
-            )}
             {isLoading && messages.length > 0 && (
               <Box sx={{ order: messages.length * 2 + 2, bgcolor: '#2f2f2f', py: 2.5, px: 4 }}>
                 <Box sx={{ maxWidth: '90%', width: '90%', mx: 'auto', display: 'flex', gap: 2 }}>


### PR DESCRIPTION
## Summary
  - Fixed bug where the most recent widget generation showed no code, no DSL,
    and no "View Preview" button, only "Here's your widget:" with blank space
  - Root cause: the latest widget had `enableLivePreview={true}` which hid its
    code block, while the inline Sandpack preview was also hidden because the
    sidebar panel was active
  - Removed the `enableLivePreview` system and inline Sandpack since the sidebar
    preview panel now handles all previews
  - All widget messages now consistently show code + "View Preview" button
  
Before:
<img width="3761" height="1912" alt="image" src="https://github.com/user-attachments/assets/caf6094d-a266-440c-8ef9-1bee135f335d" />

After:
<img width="3817" height="1953" alt="image" src="https://github.com/user-attachments/assets/04a448ad-ca7b-483d-bd44-c053842cf59a" />
